### PR TITLE
Add CreatorSkills to Design & Content section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ From **LLMs** to **computer vision**, **MLOps** to **AI ethics**, this repo is y
 - [Midjourney](https://www.midjourney.com/)
 - [Runway ML](https://runwayml.com/)
 - [ElevenLabs](https://elevenlabs.io/)
+- [CreatorSkills](https://creatorskills.co/) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 
 ---
 


### PR DESCRIPTION
## What's being added

[CreatorSkills](https://creatorskills.co) — Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.

Added to the **AI Tools & Apps → Design & Content** section alongside Midjourney, Runway ML, and ElevenLabs.

## Why it fits

CreatorSkills provides AI-powered skill packages specifically for content creators, complementing the existing design & content tools in this section.